### PR TITLE
Ordering and same unit precedence constraints

### DIFF
--- a/fjsp/CpModel.py
+++ b/fjsp/CpModel.py
@@ -72,7 +72,7 @@ def create_cp_model(data: ProblemData) -> CpModel:
     ]
     m.add(m.minimize(m.max(completion_times)))
 
-    # Obey the operation precedence constraints.
+    # Obey the operation timing precedence constraints.
     for frm, to, attr in data.operations_graph.edges(data=True):
         frm = m.variables[f"O_{frm}"]
         to = m.variables[f"O_{to}"]
@@ -94,8 +94,27 @@ def create_cp_model(data: ProblemData) -> CpModel:
                 m.add(m.end_before_start(frm, to))
             elif prec_type == "end_before_end":
                 m.add(m.end_before_end(frm, to))
-            else:
-                raise ValueError(f"Unknown precedence type: {prec_type}")
+
+    # Obey the operation ordering precedence constraints.
+    for machine, ops in data.machine2ops.items():
+        seq_var = m.variables[f"S_{machine.idx}"]
+
+        for op1, op2 in product(ops, repeat=2):
+            if op1 == op2:
+                continue
+
+            if (op1.idx, op2.idx) not in data.operations_graph.edges:
+                continue
+
+            var1 = m.variables[f"A_{op1.idx}_{machine.idx}"]
+            var2 = m.variables[f"A_{op2.idx}_{machine.idx}"]
+            edge = data.operations_graph.edges[op1.idx, op2.idx]
+
+            for prec_type in edge["precedence_types"]:
+                if prec_type == "previous":
+                    m.add(m.previous(seq_var, var1, var2))
+                elif prec_type == "before":
+                    m.add(m.before(seq_var, var1, var2))
 
     # An operation must be scheduled on exactly one machine.
     for op in data.operations:

--- a/fjsp/CpModel.py
+++ b/fjsp/CpModel.py
@@ -115,6 +115,8 @@ def create_cp_model(data: ProblemData) -> CpModel:
                     m.add(m.previous(seq_var, var1, var2))
                 elif prec_type == "before":
                     m.add(m.before(seq_var, var1, var2))
+                elif prec_type == "same_unit":
+                    m.add(m.presence_of(var1) == m.presence_of(var2))
 
     # An operation must be scheduled on exactly one machine.
     for op in data.operations:

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -117,6 +117,10 @@ class Model:
         ),
         edge_type: Optional[str] = None,
     ):
+        if any(pt not in PrecedenceType for pt in precedence_types):
+            msg = "Precedence types must be of type PrecedenceType."
+            raise ValueError(msg)
+
         self._operations_graph.add_edge(
             operation1.idx,
             operation2.idx,

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -114,7 +114,7 @@ class Model:
         operation2: Operation,
         precedence_types: Iterable[PrecedenceType] = (
             PrecedenceType.END_BEFORE_START,
-        ),  # TODO: can an edge have multiple precedence types?
+        ),
         edge_type: Optional[str] = None,
     ):
         self._operations_graph.add_edge(

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import Optional
 
 import networkx as nx
@@ -65,7 +65,12 @@ class Operation:
         return self.name if self.name else f"Operation {self.idx}"
 
 
-class PrecedenceType(str, Enum):
+class PrecedenceTypeMeta(EnumMeta):
+    def __contains__(cls, item):
+        return item in cls._value2member_map_ or item in cls.__members__
+
+
+class PrecedenceType(str, Enum, metaclass=PrecedenceTypeMeta):
     """
     Types of precendence constraints between two operations $i$ and $j$.
     Let $s(i)$ and $f(i)$ be the start and finish times of operation $i$,

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -80,6 +80,8 @@ class PrecedenceType(str, Enum):
     - end_at_end:            $f(i) == f(j)$
     - end_before_start:      $f(i) <= s(j)$
     - end_before_end:        $f(i) <= f(j)$
+    - before:                i comes before j in sequence variable.
+    - previous:              i is previous to j in sequence variable.
     """
 
     START_AT_START = "start_at_start"
@@ -90,6 +92,8 @@ class PrecedenceType(str, Enum):
     END_AT_END = "end_at_end"
     END_BEFORE_START = "end_before_start"
     END_BEFORE_END = "end_before_end"
+    PREVIOUS = "previous"
+    BEFORE = "before"
 
 
 class ProblemData:

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -82,6 +82,7 @@ class PrecedenceType(str, Enum):
     - end_before_end:        $f(i) <= f(j)$
     - before:                i comes before j in sequence variable.
     - previous:              i is previous to j in sequence variable.
+    - same_unit:             i and j are processed on the same unit.
     """
 
     START_AT_START = "start_at_start"
@@ -94,6 +95,7 @@ class PrecedenceType(str, Enum):
     END_BEFORE_END = "end_before_end"
     PREVIOUS = "previous"
     BEFORE = "before"
+    SAME_UNIT = "same_unit"
 
 
 class ProblemData:

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -147,3 +147,15 @@ class ProblemData:
     @property
     def machine2ops(self) -> dict[Machine, list[Operation]]:
         return self._machine2ops
+
+    @property
+    def num_jobs(self) -> int:
+        return len(self._jobs)
+
+    @property
+    def num_machines(self) -> int:
+        return len(self._machines)
+
+    @property
+    def num_operations(self) -> int:
+        return len(self._operations)

--- a/fjsp/plot.py
+++ b/fjsp/plot.py
@@ -5,9 +5,16 @@ from .ProblemData import ProblemData
 from .Solution import Solution
 
 
-def plot(data: ProblemData, solution: Solution):
+def plot(data: ProblemData, solution: Solution, plot_labels: bool = True):
     """
     Plots a Gantt chart of the solver result.
+
+    Parameters
+    ----------
+    data: ProblemData
+        The problem data instance.
+    solution: Solution
+        A solution to the problem.
     """
     fig, ax = plt.subplots(1, 1, figsize=(12, 8))
 
@@ -23,21 +30,19 @@ def plot(data: ProblemData, solution: Solution):
         )
 
         # Plot each scheduled operation as a single horizontal bar (interval).
-        kwargs = {
-            "color": colors[op.job.idx],
-            "linewidth": 1,
-            "edgecolor": "k",
-        }
+        color = colors[op.job.idx]
+        kwargs = {"color": color, "linewidth": 1, "edgecolor": "black"}
         ax.barh(machine, duration, left=start, **kwargs)
 
-        # Add the operation ID at the center of the interval.
-        midpoint = start + duration / 2
-        ax.text(midpoint, machine, op.idx, ha="center", va="center")
+        if plot_labels:
+            # Add the operation ID at the center of the interval.
+            center = start + duration / 2
+            ax.text(center, machine, op.idx, ha="center", va="center")
 
-    ax.set_yticks(
-        ticks=range(len(data.machines)),
-        labels=[str(machine) for machine in data.machines],
-    )
+    labels = [str(machine) for machine in data.machines]
+    ax.set_yticks(ticks=range(len(data.machines)), labels=labels)
+    ax.set_ylim(ax.get_ylim()[::-1])
+
     ax.set_xlabel("Time")
     ax.set_title("Solution")
 


### PR DESCRIPTION
Closes #10. This PR adds three precedence constraints: previous, before, and same unit. This allows to force one operation to be scheduled after another on the same machine.